### PR TITLE
Add pages parameter to select specific pages or page ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,14 @@ llm -f pdf-to-images:path/to/document.pdf 'Summarize this document'
 ### Fragment syntax
 
 ```
-pdf-to-images:<path>?dpi=N&format=jpg|png&quality=Q
+pdf-to-images:<path>?dpi=N&format=jpg|png&quality=Q&pages=P
 ```
 
 - `<path>`: Path to the PDF file accessible to the environment where LLM runs.
 - `dpi=N`: (optional) Dots per inch to use when rendering the PDF pages, which affects the resolution of the output images. Defaults to `300` if omitted.
 - `format=jpg|png`: (optional) Image format to use for the output. Can be either `jpg` (default) or `png`.
 - `quality=Q`: (optional) JPEG quality factor between 1 and 100. Only applies when using JPG format. Defaults to `30` if omitted. Higher values produce better quality but larger file sizes.
+- `pages=P`: (optional) Specific pages or page ranges to convert, e.g., "1,3-5". If omitted, all pages are converted.
 
 ### More examples
 
@@ -60,10 +61,16 @@ Convert a PDF with high-quality JPG images:
 llm -f 'pdf-to-images:document.pdf?quality=90' 'extract all visible text'
 ```
 
+Convert specific pages or page ranges of a PDF:
+
+```bash
+llm -f 'pdf-to-images:document.pdf?pages=1,3-5' 'summarize selected pages'
+```
+
 Combine multiple parameters:
 
 ```bash
-llm -f 'pdf-to-images:document.pdf?dpi=450&format=jpg&quality=75' 'OCR'
+llm -f 'pdf-to-images:document.pdf?dpi=450&format=jpg&quality=75&pages=2,4-6' 'OCR selected pages'
 ```
 
 ## Development

--- a/tests/test_pdf_to_images.py
+++ b/tests/test_pdf_to_images.py
@@ -15,3 +15,15 @@ def test_pdf_to_images():
     # Now delete them
     out_dir = os.path.dirname(attachments[0].path)
     shutil.rmtree(out_dir)
+
+
+def test_pdf_to_images_with_pages():
+    path = os.path.join(os.path.dirname(__file__), "blank-pages.pdf")
+    attachments = pdf_to_images_loader(f"{path}?pages=1")
+    assert isinstance(attachments, list)
+    assert len(attachments) == 1
+    assert all(isinstance(attachment, llm.Attachment) for attachment in attachments)
+    assert attachments[0].path.endswith("page_001.jpg")
+    # Now delete them
+    out_dir = os.path.dirname(attachments[0].path)
+    shutil.rmtree(out_dir)


### PR DESCRIPTION
Fixes #2

Add support for selecting specific pages or page ranges for conversion to images.

* Add a new `pages` parameter to the `pdf_to_images_loader` function in `llm_pdf_to_images.py` to allow selecting specific pages or page ranges.
* Implement the `parse_pages` function to parse the `pages` parameter and extract specific pages and page ranges.
* Modify the loop in `pdf_to_images_loader` to process only the specified pages or page ranges.
* Update the docstring in `pdf_to_images_loader` to include the `pages` parameter.
* Update `README.md` to document the `pages` parameter and provide examples of its usage.
* Add a new test case in `tests/test_pdf_to_images.py` to verify the functionality of the `pages` parameter.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/simonw/llm-pdf-to-images/issues/2?shareId=XXXX-XXXX-XXXX-XXXX).